### PR TITLE
Fix issue with ThrottleManager error thrown

### DIFF
--- a/providers/ThrottleProvider.js
+++ b/providers/ThrottleProvider.js
@@ -19,8 +19,7 @@ class ThrottleProvider extends ServiceProvider {
     this.app.manager('Adonis/Addons/Throttle', require('../src/Manager'))
 
     this.app.bind('Adonis/Addons/ThrottleManager', () => {
-      const ThrottleManager = require('../src/Manager')
-      return new ThrottleManager()
+      return require('../src/Manager')
     })
 
     this.app.singleton('Adonis/Addons/Throttle', app => {

--- a/src/Manager.js
+++ b/src/Manager.js
@@ -68,4 +68,4 @@ class ThrottleManager {
   }
 }
 
-module.exports = ThrottleManager
+module.exports = new ThrottleManager()

--- a/test/ThrottleManagerTest.js
+++ b/test/ThrottleManagerTest.js
@@ -5,13 +5,11 @@ const { ioc } = require('@adonisjs/fold')
 const GE = require('@adonisjs/generic-exceptions')
 const { Config } = require('@adonisjs/sink')
 
-const ThrottleManager = require('../src/Manager')
+const manager = require('../src/Manager')
 const drivers = require('../src/Drivers')
 const Cache = require('../src/Drivers/Cache')
 
 describe('ThrottleManager', () => {
-  const manager = new ThrottleManager()
-
   before(() => {
     ioc.singleton('Adonis/Src/Config', () => new Config())
     ioc.singleton('Adonis/Addons/Redis', () => class Redis {


### PR DESCRIPTION
Fix issue with `ThrottleManager` so that module exports a constructed object similar to other core Adonis managers.

- Installing masasron/adonis-throttle@2.3.2 with README install instructions results with the following error when starting
the application:

> `With InvalidArgumentException: E_INVALID_IOC_MANAGER: Make sure Adonis/Addons/Throttle does have a extend method.`

This is because the `this.app.manager` in `ThrottleProvider` `register()` expects a function (i.e. a constructed class instance)
This was already done in the following `this.app.bind` call.

This commit ensures the calls to `this.app.manager` and `this.app.bind` are the same functions by exporting `new ThrottleManager()` in
`Manager.js`.

`ThrottleManagerTest.js` also adapted to inject the constructed manager function from `Manager.js`.